### PR TITLE
Rewrite to be callback based and not use atomically

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,19 @@
-# Atomically universal
+# Atomic-file-rw
 
-A wrapper around
-[atomically](https://github.com/fabiospampinato/atomically) that
-enables it to also run in the browser by writing to indexed db.
-
-This module only exposes the non-sync methods and can be used as a
-replacement for [atomic-file](https://github.com/flumedb/atomic-file)
-as it has better error handling on node.
+This module is meant as a replacement for
+[atomic-file](https://github.com/flumedb/atomic-file) as it has better
+error handling on node and is faster in the browser.
 
 ## Example
 
 Write a buffer to file and read it again:
 
 ```js
-const { readFile, writeFile } = require('atomically-universal')
+const { readFile, writeFile } = require('atomic-file-rw')
 
-writeFile("test.txt", Buffer.from('GREETINGS')).then(x => {
-  readFile("test.txt").then(buf => {
+writeFile("test.txt", Buffer.from('GREETINGS'), ((err, x) => {
+  readFile("test.txt", (err, buf) => {
     console.log(buf.toString())
   })
 })
 ```
-
-or
-
-```js
-const { readFile, writeFile } = require('atomically-universal')
-
-await writeFile("test.txt", Buffer.from('GREETINGS'))
-const buf = await readFile("test.txt")
-
-console.log(buf.toString())
-```
-

--- a/browser.js
+++ b/browser.js
@@ -1,0 +1,29 @@
+const IdbKvStore = require('idb-kv-store')
+
+function getStoreAndKey(filename) {
+  const parts = filename.split('/')
+  const key = parts.pop()
+  const storename = parts.join('/')
+  const store = new IdbKvStore(storename, { disableBroadcast: true })
+  return { store, key }
+}
+
+function isUint8Array(value) {
+  return toString.call(value).indexOf('Uint8Array') !== -1
+}
+
+module.exports = {
+  readFile: function(filename, opts, cb) {
+    if (!cb) opts = cb
+    const { store, key } = getStoreAndKey(filename)
+    const storeGet = store.get.bind(store)
+    storeGet(key, (err, value) => {
+      if (err) return cb(err)
+      else cb(null, isUint8Array(value) ? Buffer.from(value) : value)
+    })
+  },
+  writeFile: function(filename, value, cb) {
+    const { store, key } = getStoreAndKey(filename)
+    return store.set.bind(store)(key, value, cb)
+  }
+}

--- a/browser/test.js
+++ b/browser/test.js
@@ -7,8 +7,8 @@ function arrEqual(lhs, rhs) {
 const greetings = Buffer.from('GREETINGS')
 console.log("Writing greetings as buffer", greetings)
 
-writeFile("test.txt", greetings).then(x => {
-  readFile("test.txt").then(buf => {
+writeFile("test.txt", greetings, (err, x) => {
+  readFile("test.txt", (err, buf) => {
     console.log("got", buf)
     console.log("checking if the result is the same", arrEqual(buf, greetings))
     console.log("checking if we can do buffer operations", buf.readUInt32LE(0))
@@ -16,12 +16,11 @@ writeFile("test.txt", greetings).then(x => {
     const greetingsStr = 'Greetings!'
     console.log("Writing greetings as string", greetingsStr)
     
-    writeFile("test2.txt", greetingsStr).then(x => {
-      readFile("test2.txt").then(str => {
+    writeFile("test2.txt", greetingsStr, (err, x) => {
+      readFile("test2.txt", (err, str) => {
         console.log("got", str)
         console.log("checking if the result is the same", str === greetingsStr)
       })
     })
-    
   })
 })

--- a/fs.js
+++ b/fs.js
@@ -1,0 +1,32 @@
+const fs = require('fs')
+
+function getEncoding(opts) {
+  return opts && opts.encoding ? opts.encoding : null
+}
+
+module.exports = {
+  readFile: function(filename, opts, cb) {
+    if (!cb) cb = opts
+    fs.readFile(filename, getEncoding(opts), cb)
+  },
+  writeFile: function(filename, value, opts, cb) {
+    if (!cb) cb = opts
+    const tempFile = filename + '~'
+    fs.open(tempFile, 'w', (err, fd) => {
+      if (err) return cb(err)
+      fs.writeFile(fd, value, getEncoding(opts), (err) => {
+        if (err) return cb(err)
+        fs.fsync(fd, (err) => {
+          if (err) return cb(err)
+          fs.close(fd, (err) => {
+            if (err) return cb(err)
+            fs.rename(tempFile, filename, function (err) {
+              if(err) cb(err)
+              else cb(null, value)
+            })
+          })
+        })
+      })
+    })
+  }
+}

--- a/index.js
+++ b/index.js
@@ -1,39 +1,4 @@
 if (typeof localStorage === "undefined" || localStorage === null)
-{
-  module.exports = require('atomically')
-}
+  module.exports = require("./fs")
 else
-{
-  const IdbKvStore = require('idb-kv-store')
-  const promisify = require('promisify-4loc')
-
-  function getStoreAndKey(filename) {
-    const parts = filename.split('/')
-    const key = parts.pop()
-    const storename = parts.join('/')
-    const store = new IdbKvStore(storename, { disableBroadcast: true })
-    return { store, key }
-  }
-
-  function isUint8Array(value) {
-    return toString.call(value).indexOf('Uint8Array') !== -1
-  }
-
-  module.exports = {
-    readFile: function(filename) {
-      const { store, key } = getStoreAndKey(filename)
-      const storeGet = store.get.bind(store)
-      function get(key, cb) {
-        storeGet(key, (err, value) => {
-          if (err) return cb(err)
-          else cb(null, isUint8Array(value) ? Buffer.from(value) : value)
-        })
-      }
-      return promisify(get)(key)
-    },
-    writeFile: function(filename, value) {
-      const { store, key } = getStoreAndKey(filename)
-      return promisify(store.set.bind(store))(key, value)
-    }
-  }
-}
+  module.exports = require("./browser")

--- a/package.json
+++ b/package.json
@@ -1,16 +1,14 @@
 {
-  "name": "atomically-universal",
+  "name": "atomic-file-rw",
   "description": "",
-  "version": "0.1.1",
-  "homepage": "https://github.com/ssb-ngi-pointer/atomically-universal",
+  "version": "0.1.0",
+  "homepage": "https://github.com/ssb-ngi-pointer/atomic-file-rw",
   "repository": {
     "type": "git",
-    "url": "git@github.com/ssb-ngi-pointer/atomically-universal.git"
+    "url": "git@github.com/ssb-ngi-pointer/atomic-file-rw.git"
   },
   "dependencies": {
-    "atomically": "^1.7.0",
-    "idb-kv-store": "^4.5.0",
-    "promisify-4loc": "^1.0.0"
+    "idb-kv-store": "^4.5.0"
   },
   "devDependencies": {
     "browserify": "^17.0.0",

--- a/test/basic.js
+++ b/test/basic.js
@@ -1,17 +1,16 @@
 const tape = require('tape')
 const { readFile, writeFile } = require('../')
 
-const greetings = Buffer.from('GREETINGS')
-
 tape('Basic', (t) => {
-  writeFile("test.txt", greetings).then(x => {
-    readFile("test.txt").then(buf => {
+  const greetings = Buffer.from('GREETINGS')
+  writeFile("test.txt", greetings, (err, x) => {
+    readFile("test.txt", (err, buf) => {
       t.deepEqual(buf, greetings)
       
       const greetingsStr = 'Greetings!'
       
-      writeFile("test2.txt", greetingsStr, { encoding: 'utf8' }).then(x => {
-        readFile("test2.txt", { encoding: 'utf8' }).then(str => {
+      writeFile("test2.txt", greetingsStr, { encoding: 'utf8' }, (err, x) => {
+        readFile("test2.txt", { encoding: 'utf8' }, (err, str) => {
           t.deepEqual(str, greetingsStr)
           t.end()
         })


### PR DESCRIPTION
This is just a starting point for where we want to have this code. 

I basically took the fs code from atomic-file and ported it over to
the readFile, writeFile api and rewrote it to fsync after write.

Some notes to discuss:

- cb based instead of promise like atomically
- atomically api (readFile, writeFile) instead of object based like atomic-file. The atomic-file api has always felt a bit clunky to me.
- There is an interesting consequence of the function vs object based in that if you have multiple writes to the file then atomic-file uses a lock, but if you a lot of writes queued up it would be better to skip all the immediate writes and just take the latest. This assumes that you would use the same object to coordinate writes to the same file.