### PR TITLE
Handle concurrent writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ This module is meant as a replacement for
 [atomic-file](https://github.com/flumedb/atomic-file) as it has better
 error handling on node and is faster in the browser.
 
+The library is written to handle writing to a few number of files in a
+ safe manor. Concurrent writes to the same file are completed in the
+ order they are started.
+
 ## Example
 
 Write a buffer to file and read it again:

--- a/browser.js
+++ b/browser.js
@@ -14,7 +14,7 @@ function isUint8Array(value) {
 
 module.exports = {
   readFile: function(filename, opts, cb) {
-    if (!cb) opts = cb
+    if (!cb) cb = opts
     const { store, key } = getStoreAndKey(filename)
     const storeGet = store.get.bind(store)
     storeGet(key, (err, value) => {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "url": "git@github.com/ssb-ngi-pointer/atomic-file-rw.git"
   },
   "dependencies": {
-    "idb-kv-store": "^4.5.0"
+    "idb-kv-store": "^4.5.0",
+    "mutexify": "^1.3.1"
   },
   "devDependencies": {
     "browserify": "^17.0.0",

--- a/test/basic.js
+++ b/test/basic.js
@@ -18,3 +18,17 @@ tape('Basic', (t) => {
     })
   })
 })
+
+tape('Concurrency', (t) => {
+  let completedWrites = 0
+  const concurency = Buffer.from('concurrency!')
+  for (var i = 0; i < 100; ++i) {
+    setTimeout(() => {
+      writeFile("test.txt", concurency, (err, x) => {
+        t.error(err, "no error")
+        if (++completedWrites === 100)
+          t.end()
+      })
+    }, Math.floor(Math.random() * 10))
+  }
+})


### PR DESCRIPTION
I hooked this module into jitdb, ran the tests and everything was failing ;-) Hence this PR. Turns out those tests are pretty good at testing concurrent writes. This PR makes sure that all writes to the same file are run one by one.