### PR TITLE
add deleteFile API

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,14 @@ atomic.writeFile("test.txt", Buffer.from('GREETINGS'), (err, x) => {
 
 ### `atomic.readFile(path[, options], callback)`
 
-Same arguments as Node.js's `fs.readFile`, but in the browser the 
+Same arguments as Node.js's `fs.readFile`, but in the browser the
 `options` is ignored.
 
 ### `atomic.writeFile(file, data[, options], callback)`
 
-Same arguments as Node.js's `fs.writeFile`, but in the browser the 
+Same arguments as Node.js's `fs.writeFile`, but in the browser the
 `options` is ignored.
+
+### `atomic.deleteFile(file, callback)`
+
+Same arguments as Node.js's `fs.unlink`.

--- a/browser.js
+++ b/browser.js
@@ -31,5 +31,9 @@ module.exports = {
 
     const { store, key } = getStoreAndKey(filename)
     return store.set.bind(store)(key, value, cb)
+  },
+  deleteFile: function(filename, cb) {
+    const { store, key } = getStoreAndKey(filename)
+    store.remove(key, cb)
   }
 }

--- a/test/basic.js
+++ b/test/basic.js
@@ -3,16 +3,17 @@
 // SPDX-License-Identifier: Unlicense
 
 const tape = require('tape')
-const { readFile, writeFile } = require('../')
+const fs = require('fs')
+const { readFile, writeFile, deleteFile } = require('../')
 
 tape('Basic', (t) => {
   const greetings = Buffer.from('GREETINGS')
   writeFile("test.txt", greetings, (err, x) => {
     readFile("test.txt", (err, buf) => {
       t.deepEqual(buf, greetings)
-      
+
       const greetingsStr = 'Greetings!'
-      
+
       writeFile("test2.txt", greetingsStr, { encoding: 'utf8' }, (err, x) => {
         readFile("test2.txt", { encoding: 'utf8' }, (err, str) => {
           t.deepEqual(str, greetingsStr)
@@ -35,4 +36,30 @@ tape('Concurrency', (t) => {
       })
     }, Math.floor(Math.random() * 10))
   }
+})
+
+tape('Delete', (t) => {
+  const greetings = Buffer.from('GREETINGS')
+  writeFile("test.txt", greetings, (err, x) => {
+    readFile("test.txt", (err, buf) => {
+      t.deepEqual(buf, greetings)
+
+      deleteFile("test.txt", (err, x) => {
+        readFile("test.txt", (err, buf) => {
+          t.ok(err, "file deleted")
+          t.end()
+        })
+      })
+    })
+  })
+})
+
+tape('teardown', (t) => {
+  try{
+    fs.unlinkSync('test.txt')
+  } catch (e) {}
+  try {
+    fs.unlinkSync('test2.txt')
+  } catch (e) {}
+  t.end()
 })


### PR DESCRIPTION
Context: I need to add delete to ssb-ebt, which uses `key-value-store-file` which uses `atomic-file-rw`, so we need to have a browser-and-nodejs delete API.